### PR TITLE
Feature/simulation speed

### DIFF
--- a/src/main/java/de/uni_hd/giscience/helios/LidarSim.java
+++ b/src/main/java/de/uni_hd/giscience/helios/LidarSim.java
@@ -98,7 +98,7 @@ public class LidarSim {
 
 		if (!headless) {
 			// Slow down simulation for visualization
-			playback.setSimSpeedFactor( 0);
+			playback.setSimSpeedFactor( 1);
 
 			JMEFrontEnd frontend = new JMEFrontEnd();
 			frontend.init(playback);

--- a/src/main/java/de/uni_hd/giscience/helios/LidarSim.java
+++ b/src/main/java/de/uni_hd/giscience/helios/LidarSim.java
@@ -97,10 +97,16 @@ public class LidarSim {
 		// ############ BEGIN Start visualization module #############
 
 		if (!headless) {
+			// Slow down simulation for visualization
+			playback.setSimSpeedFactor( 0);
+
 			JMEFrontEnd frontend = new JMEFrontEnd();
 			frontend.init(playback);
 			frontend.start();
 			playback.pause(true);
+
+		} else {
+			playback.setSimSpeedFactor( 0);
 		}
 		// ############ END Start visualization module #############
 

--- a/src/main/java/de/uni_hd/giscience/helios/core/Simulation.java
+++ b/src/main/java/de/uni_hd/giscience/helios/core/Simulation.java
@@ -98,11 +98,12 @@ public abstract class Simulation {
 	protected abstract void onLegComplete();
 
 	public void pause(boolean pause) {
-		this.mPaused = pause;
-		SebEvents.events.fire("simulation_pause_state_changed", this.mPaused);
       lock.lock();
-        condPause.signal();
+      this.mPaused = pause;
+      condPause.signal();
       lock.unlock();
+
+      SebEvents.events.fire("simulation_pause_state_changed", this.mPaused);
 	}
 
 	protected void setScanner(Scanner scanner) {

--- a/src/main/java/de/uni_hd/giscience/helios/core/scanner/Measurement.java
+++ b/src/main/java/de/uni_hd/giscience/helios/core/scanner/Measurement.java
@@ -13,4 +13,5 @@ public class Measurement {
 	public double intensity = 0;
 	public int returnNumber;
 	public int fullwaveIndex;
+	public Long gpsTime;
 }

--- a/src/main/java/de/uni_hd/giscience/helios/core/scanner/Scanner.java
+++ b/src/main/java/de/uni_hd/giscience/helios/core/scanner/Scanner.java
@@ -38,7 +38,6 @@ public class Scanner extends Asset {
 	boolean state_lastPulseWasHit = false;
 	boolean state_isActive = true;
 
-	
 	public Scanner(double beamDiv_rad, Vector3D beamOrigin, Rotation beamOrientation, ArrayList<Integer> pulseFreqs, double pulseLength_ns, String visModel) {
 		
 		// Configure emitter:
@@ -64,7 +63,7 @@ public class Scanner extends Asset {
 	}
 
 	
-	public void doSimStep(ExecutorService execService) {
+	public void doSimStep(ExecutorService execService, Long currentGpsTime) {
 
 		// Update head attitude (we do this even when the scanner is inactive):
 		scannerHead.doSimStep(cfg_setting_pulseFreq_Hz);
@@ -90,10 +89,6 @@ public class Scanner extends Asset {
 		// Calculate absolute beam attitude:
 		Rotation mountRelativeEmitterAttitude = this.scannerHead.getMountRelativeAttitude().applyTo(this.cfg_device_headRelativeEmitterAttitude);
 		Rotation absoluteBeamAttitude = platform.getAbsoluteMountAttitude().applyTo(mountRelativeEmitterAttitude).applyTo(beamDeflector.getEmitterRelativeAttitude());
-
-		// Caclulate time of the emitted pulse
-		Long unixTime = System.currentTimeMillis() / 1000L;
-		Long currentGpsTime = (unixTime - 315360000) - 1000000000;
 
 		detector.simulatePulse(execService, absoluteBeamOrigin, absoluteBeamAttitude, state_currentPulseNumber, currentGpsTime);
 	}

--- a/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/AbstractDetector.java
+++ b/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/AbstractDetector.java
@@ -23,7 +23,7 @@ public abstract class AbstractDetector {
 	public int cfg_setting_beamSampleQuality = 1;
 
 	// File output:
-	String outputFileLineFormatString = "%.3f %.3f %.3f %.4f \"%s\"";
+	String outputFileLineFormatString = "%.3f %.3f %.3f %.4f \"%s\" %d";
 	BufferedWriter mPointsFileWriter = null;
 
 	String outputFilePath;
@@ -76,7 +76,7 @@ public abstract class AbstractDetector {
 		}
 	}
 
-	public abstract void simulatePulse(ExecutorService execService, Vector3D absoluteBeamOrigin, Rotation absoluteBeamAttitude, int state_currentPulseNumber, long currentGpsTime);
+	public abstract void simulatePulse(ExecutorService execService, Vector3D absoluteBeamOrigin, Rotation absoluteBeamAttitude, int state_currentPulseNumber, Long currentGpsTime);
 
 	synchronized public void shutdown() {
 
@@ -100,7 +100,7 @@ public abstract class AbstractDetector {
 
 			// String line = String.format(outputFileLineFormatString, shifted.getX(), shifted.getY(), shifted.getZ(), m.intensity, m.returnNumber, m.fullwaveIndex);
 
-			String line = String.format(outputFileLineFormatString, shifted.getX(), shifted.getY(), shifted.getZ(), m.intensity, m.hitObjectId);
+			String line = String.format(outputFileLineFormatString, shifted.getX(), shifted.getY(), shifted.getZ(), m.intensity, m.hitObjectId, m.gpsTime);
 
 			line += "\n";
 

--- a/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/AbstractPulseRunnable.java
+++ b/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/AbstractPulseRunnable.java
@@ -126,6 +126,7 @@ public abstract class AbstractPulseRunnable implements Runnable {
 		Vector3D pointPos = beamOrigin.add(beamDir.scalarMultiply(distance));
 
 		Measurement m = new Measurement();
+		m.gpsTime = currentGpsTime;
 		m.position = pointPos;
 		m.distance = distance;
 		m.intensity = intensity;

--- a/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/FullWaveformPulseDetector.java
+++ b/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/FullWaveformPulseDetector.java
@@ -51,7 +51,7 @@ public class FullWaveformPulseDetector extends AbstractDetector {
 	}
 
 	@Override
-	public void simulatePulse(ExecutorService execService, Vector3D absoluteBeamOrigin, Rotation absoluteBeamAttitude, int state_currentPulseNumber, long currentGpsTime) {
+	public void simulatePulse(ExecutorService execService, Vector3D absoluteBeamOrigin, Rotation absoluteBeamAttitude, int state_currentPulseNumber, Long currentGpsTime) {
 		// TODO Auto-generated method stub
 
 		// Submit pulse computation task to multithread executor service:

--- a/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/SingleRayPulseDetector.java
+++ b/src/main/java/de/uni_hd/giscience/helios/core/scanner/detector/SingleRayPulseDetector.java
@@ -17,7 +17,7 @@ public class SingleRayPulseDetector extends AbstractDetector {
 	// TODO 3: Perhaps return PulseRunnable and let the Scanner class submit it, instead of submitting it here?
 
 	@Override
-	public void simulatePulse(ExecutorService execService, Vector3D absoluteBeamOrigin, Rotation absoluteBeamAttitude, int state_currentPulseNumber, long currentGpsTime) {
+	public void simulatePulse(ExecutorService execService, Vector3D absoluteBeamOrigin, Rotation absoluteBeamAttitude, int state_currentPulseNumber, Long currentGpsTime) {
 
 		AbstractPulseRunnable worker = new SingleRayPulseRunnable(this, absoluteBeamOrigin, absoluteBeamAttitude, state_currentPulseNumber, currentGpsTime);
 


### PR DESCRIPTION
I tried to increase the simulation speed. 
Therefore i needed to remove all simulation delays in the simulation. This is done by a playback parameter for the simulation speed, (Zero will have no delaying). 

Additional there where some race conditions which are fixed by delaying. Now they are replaced by mutex`s and condition variables.

I extended the simulation by a GPS time propagation to the scanner simulation, detector. So that the time base only calculated on one component and used by all other. There was one problem with different time in the system, and a wrong UNIX to GPS time transformation.

I'm not sure if the GPS time is the write time for the simulation. But there are other problems to.
Which unit should the time base have sec, ms, ns?
I think the detector should have a ns time base and converts it to a sec gps time. This will give the system the most flexibility. And the ray simulation get with ns the exact time.

What is your opinion?